### PR TITLE
Allowing to pass elements to saveElementScreenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ available:
   exclude frequently changing parts of your screenshot, you can either pass all kinds of different [WebdriverIO selector strategies](http://webdriver.io/guide/usage/selectors.html)
   that queries one or multiple elements or you can define x and y values which stretch a rectangle or polygon
 
-* **hide** `String[]`<br>
+* **hide** `String[] | Element[]`<br>
   hides all elements queried by all kinds of different [WebdriverIO selector strategies](http://webdriver.io/guide/usage/selectors.html) (via `opacity: 0`)
 
-* **remove** `String[]`<br>
+* **remove** `String[] | Element[]`<br>
   removes all elements queried by all kinds of different [WebdriverIO selector strategies](http://webdriver.io/guide/usage/selectors.html) (via `display: none`)
 
 ## Use GraphicsMagick

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ wdio-screenshot enhances an WebdriverIO instance with the following commands:
 
 * `browser.saveViewportScreenshot([fileName], [{options}]);`
 * `browser.saveDocumentScreenshot([fileName], [{options}]);`
-* `browser.saveElementScreenshot([fileName], elementSelector, [{options}]);`
+* `browser.saveElementScreenshot([fileName], elementOrSelector, [{options}]);`
 
 
 All of these provide options that will help you to exclude unrelevant parts (e.g. content). The following options are

--- a/src/commands/saveElementScreenshot.js
+++ b/src/commands/saveElementScreenshot.js
@@ -2,6 +2,12 @@ import _ from 'lodash';
 import makeElementScreenshot from '../modules/makeElementScreenshot';
 import saveBase64Image from '../utils/saveBase64Image';
 
+function isElementOrSelector(obj) {
+  return _.isString(obj)
+    || _.isArray(obj)
+    || (_.isObject(obj) && obj.hasOwnProperty("selector"));
+}
+
 /**
  * @alias browser.saveElementScreenshot
  * @param {string=} fileName
@@ -12,17 +18,17 @@ import saveBase64Image from '../utils/saveBase64Image';
 // Note: function name must be async to signalize WebdriverIO that this function returns a promise
 export default async function async(fileName, elementSelector, options) {
 
-  if ((_.isString(fileName) || _.isArray(fileName)) && _.isPlainObject(elementSelector) && _.isUndefined(options)) {
+  if (isElementOrSelector(fileName) && _.isPlainObject(elementSelector) && _.isUndefined(options)) {
     options = elementSelector;
     elementSelector = fileName;
     fileName = undefined;
-  } else if ((_.isString(fileName) || _.isArray(fileName)) && _.isUndefined(elementSelector)) {
+  } else if (isElementOrSelector(fileName) && _.isUndefined(elementSelector)) {
     elementSelector = fileName;
     fileName = undefined;
   }
 
-  if (!(_.isString(elementSelector) || _.isArray(elementSelector))) {
-    throw new Error('Please pass a valid selector value to parameter elementSelector');
+  if (!isElementOrSelector(elementSelector)) {
+    throw new Error('Please pass a valid selector or element value to parameter elementSelector');
   }
 
   // make screenshot of area

--- a/src/modules/afterScreenshot.js
+++ b/src/modules/afterScreenshot.js
@@ -4,6 +4,8 @@ import scrollbars from '../scripts/scrollbars';
 import removeElements from '../scripts/removeElements';
 import hideElements from '../scripts/hideElements';
 
+import getElements from '../utils/getElements';
+
 const log = debug('wdio-screenshot:afterScreenshot');
 
 export default async function afterScreenshot(browser, options) {
@@ -13,7 +15,7 @@ export default async function afterScreenshot(browser, options) {
 
 
         for (let i = 0; i < options.hide.length; i++) {
-            let elements = await browser.$$(options.hide[i]);
+            let elements = await getElements(options.hide[i]);
             await browser.execute(hideElements, elements, false);
         }
     }
@@ -23,7 +25,7 @@ export default async function afterScreenshot(browser, options) {
         log('add the following elements again: %s', options.remove.join(', '));
 
       for (let i = 0; i < options.remove.length; i++) {
-        let elements = await browser.$$(options.remove[i]);
+        let elements = await getElements(options.remove[i]);
         await browser.execute(removeElements, elements, false);
       }
     }

--- a/src/modules/beforeScreenshot.js
+++ b/src/modules/beforeScreenshot.js
@@ -6,6 +6,8 @@ import removeElements from '../scripts/removeElements';
 import triggerResize from '../scripts/triggerResize';
 import hideElements from '../scripts/hideElements';
 
+import getElements from '../utils/getElements';
+
 const log = debug('wdio-screenshot:beforeScreenshot');
 
 export default async function beforeScreenshot(browser, options) {
@@ -21,7 +23,7 @@ export default async function beforeScreenshot(browser, options) {
     log('hide the following elements: %s', options.hide.join(', '));
 
     for (let i = 0; i < options.hide.length; i++) {
-      let elements = await browser.$$(options.hide[i]);
+      let elements = await getElements(options.hide[i]);
       await browser.execute(hideElements, elements, true);
     }
   }
@@ -32,7 +34,7 @@ export default async function beforeScreenshot(browser, options) {
     log('remove the following elements: %s', options.remove.join(', '));
 
     for (let i = 0; i < options.remove.length; i++) {
-      let elements = await browser.$$(options.remove[i]);
+      let elements = await getElements(options.remove[i]);
       await browser.execute(removeElements, elements, true);
     }
   }

--- a/src/modules/makeElementScreenshot.js
+++ b/src/modules/makeElementScreenshot.js
@@ -1,4 +1,5 @@
 import debug from 'debug';
+import _ from 'lodash';
 
 import makeAreaScreenshot from './makeAreaScreenshot';
 import beforeScreenshot from './beforeScreenshot';
@@ -18,7 +19,15 @@ export default async function makeElementScreenshot(browser, elementSelector, op
 
   // get bounding rect of elements
 
-  const elements = await browser.$$(elementSelector);
+  let elements;
+  if (_.isString(elementSelector)) {
+    elements = await browser.$$(elementSelector);
+  } else if (_.isArray(elementSelector)) {
+    elements = elementSelector
+  } else {
+    elements = [elementSelector];
+  }
+
   const boundingRects = await browser.execute(getBoundingRects, elements);
 
   const boundingRect = groupBoundingRect(boundingRects);

--- a/src/modules/makeElementScreenshot.js
+++ b/src/modules/makeElementScreenshot.js
@@ -1,5 +1,4 @@
 import debug from 'debug';
-import _ from 'lodash';
 
 import makeAreaScreenshot from './makeAreaScreenshot';
 import beforeScreenshot from './beforeScreenshot';

--- a/src/modules/makeElementScreenshot.js
+++ b/src/modules/makeElementScreenshot.js
@@ -5,6 +5,7 @@ import makeAreaScreenshot from './makeAreaScreenshot';
 import beforeScreenshot from './beforeScreenshot';
 import afterScreenshot from './afterScreenshot';
 
+import getElements from '../utils/getElements';
 import groupBoundingRect from '../utils/groupBoundingRect';
 import getBoundingRects from '../scripts/getBoundingRects';
 
@@ -19,15 +20,7 @@ export default async function makeElementScreenshot(browser, elementSelector, op
 
   // get bounding rect of elements
 
-  let elements;
-  if (_.isString(elementSelector)) {
-    elements = await browser.$$(elementSelector);
-  } else if (_.isArray(elementSelector)) {
-    elements = elementSelector
-  } else {
-    elements = [elementSelector];
-  }
-
+  const elements = await getElements(elementSelector);
   const boundingRects = await browser.execute(getBoundingRects, elements);
 
   const boundingRect = groupBoundingRect(boundingRects);

--- a/src/utils/getElements.js
+++ b/src/utils/getElements.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 export default async function getElements(elementOrSelector) {
   if (_.isString(elementOrSelector)) {
     return await browser.$$(elementOrSelector);

--- a/src/utils/getElements.js
+++ b/src/utils/getElements.js
@@ -1,0 +1,9 @@
+export default async function getElements(elementOrSelector) {
+  if (_.isString(elementOrSelector)) {
+    return await browser.$$(elementOrSelector);
+  } else if (_.isArray(elementOrSelector)) {
+    return elementOrSelector
+  } else {
+    return [elementOrSelector];
+  }
+}

--- a/test/wdio/specs/desktop.test.js
+++ b/test/wdio/specs/desktop.test.js
@@ -132,6 +132,16 @@ describe('integration tests for desktop browsers', function () {
         await compareImages(screenPath, screenStaticElemenentFooter);
       });
 
+      it('accepts wdio elements instead of selectors', async function () {
+        const screenPath = path.join(tmpDir, '/desktop-static-element-footer_'+name+'.png');
+
+        await browser.setWindowSize(480, 500);
+        await browser.pause(500);
+        await browser.saveElementScreenshot(screenPath, $('.footer'));
+
+        await compareImages(screenPath, screenStaticElemenentFooter);
+      });
+
       it('with window size 1600px', async function () {
         const screenPath = path.join(tmpDir, '/desktop-static-element-footer_'+name+'.png');
 


### PR DESCRIPTION
Currently `saveElementScreenshot` only takes element selectors and calls `browser.$$` to find them.

This PR introduces the possibility to pass the result of `browser.$` or `browser.$$` directly to `saveElementScreenshot` (without breaking the old behavior).

This is useful for example if

* one uses page models with getters that return elements
* one uses nested selectors (`$('.outer').$('.inner')`)